### PR TITLE
This fixes the dialogs for Shoppe.

### DIFF
--- a/vendor/assets/javascripts/nifty/dialog.coffee
+++ b/vendor/assets/javascripts/nifty/dialog.coffee
@@ -65,7 +65,7 @@ window.Nifty.Dialog =
     # if we have a width, set the width for the dialog
     if options.width?
       insertedDialog.css('width', "#{options.width}px")
-      insertedDialog.css('margin-left', "-#{options.width / 2}px")
+      insertedDialog.css('margin-left', "#{options.width / 2}px")
 
     if options.offset?
       insertedDialog.css('margin-top', "#{options.offset}px")


### PR DESCRIPTION
I don't know why this minus sign is in front of the value, but it causes the left margin to always be a negative value. I'm using Nifty-Dialog in Shoppe, and this patch fixes the modals for the admin interface.
